### PR TITLE
fix: update verification URL and release 1.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+## [1.1.1] - 2026-04-23
+
+### 🚀 Added
+
+- Add LinkedIn Docs reference for organization ID (003e148)
+
+### 🐞 Fixed
+
+- Update verification URL in README and main_panel to use correct endpoint (962d67f)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Moodle plugin that adds an **“Add certificate to LinkedIn”** button to **C
 
 * **LinkedIn Add-to-profile** button on each issued certificate (from *Custom certificate*).
 * **Provider AI** integration (another Buen Data plugin) to **suggest LinkedIn post copy**.
-* Public verification link (`verify.php?code=...`) included automatically.
+* Public verification link (`verify_certificate.php?code=...`) included automatically.
 * Complies with Moodle’s privacy API; **no additional personal data** is stored.
 * Languages: English (default), Spanish, German, French, Portuguese, Indonesian, and Russian.
 

--- a/classes/output/main_panel.php
+++ b/classes/output/main_panel.php
@@ -90,7 +90,7 @@ class main_panel implements renderable, templatable {
             $certname  = format_string($customcert->name, true, ['context' => $context]);
             $issuedts  = (int) $issue->timecreated;
             $certid    = $issue->code;
-            $verifyurl = (new moodle_url('/mod/customcert/verify.php', ['code' => $issue->code]))->out(false);
+            $verifyurl = (new moodle_url('/mod/customcert/verify_certificate.php', ['code' => $issue->code]))->out(false);
 
             $shareurl = \local_socialcert\output\linkedin_helper::build_linkedin_url(
                 certname: $certname,

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_socialcert';
-$plugin->release = '1.1.0';
+$plugin->release = '1.1.1';
 $plugin->version = 2026042300;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_socialcert';
 $plugin->release = '1.1.0';
-$plugin->version = 2025121200;
+$plugin->version = 2026042300;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 501];


### PR DESCRIPTION
Closes #14

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Summary
- bump local_socialcert to release 1.1.1 / build 2026042300
- switch the public verification link to /mod/customcert/verify_certificate.php and document it in README
- add CHANGES.md entry covering the LinkedIn doc reference and verification fix

## Testing
- [x] Manually verified the LinkedIn share now points to verify_certificate.php